### PR TITLE
Wrap helper_method calls in respond_to?(:helper_method)

### DIFF
--- a/lib/leather/action_controller_extension.rb
+++ b/lib/leather/action_controller_extension.rb
@@ -4,7 +4,9 @@ module Leather
 
     included do
       extend        ClassMethods
-      helper_method :current_tab, :current_tab?
+      if respond_to?(:helper_method)
+        helper_method :current_tab, :current_tab?
+      end
     end
 
     protected


### PR DESCRIPTION
#helper_method is not essential to the functionality of the methods inside Leather::ActionControllerExtension, so this PR wraps all Leather #helper_method calls with respond_to?(:helper_method) checks.
